### PR TITLE
Bump libsodium to 1.0.12

### DIFF
--- a/packages/libsodium/Makefile
+++ b/packages/libsodium/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsodium
-PKG_VERSION:=1.0.11
-PKG_RELEASE:=2
+PKG_VERSION:=1.0.12
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.libsodium.org/libsodium/releases
-PKG_MD5SUM:=b58928d035064b2a46fb564937b83540
+PKG_MD5SUM:=c308e3faa724b630b86cc0aaf887a5d4
 
 PKG_FIXUP:=libtool autoreconf
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Libsodium 已经更新到 1.0.12 并提供 xchacha 支持。
luci界面或许同样需要此更新。

Signed-off-by: Simon <simonsmh@gmail.com>